### PR TITLE
Fix script generation order

### DIFF
--- a/kubeadm-clusters/virtualbox/tools/lab-script-generator.py
+++ b/kubeadm-clusters/virtualbox/tools/lab-script-generator.py
@@ -61,7 +61,7 @@ def write_script(filename: str, script: list):
 output_file_no = 1
 script = []
 output_file = None
-for doc in glob.glob(os.path.join(docs_path, '*.md')):
+for doc in sorted(glob.glob(os.path.join(docs_path, '*.md'))):
     print(doc)
     state = State.NONE
     ignore_next_script = False


### PR DESCRIPTION
## Summary
- generate lab scripts in consistent numeric order by sorting the list of documentation files

## Testing
- `python3 -m py_compile kubeadm-clusters/virtualbox/tools/lab-script-generator.py`


------
https://chatgpt.com/codex/tasks/task_e_683fdd8e3088832b8c668bdf4e0d6a81