### PR TITLE
Fix docs script generator path search

### DIFF
--- a/kubeadm-clusters/virtualbox/tools/lab-script-generator.py
+++ b/kubeadm-clusters/virtualbox/tools/lab-script-generator.py
@@ -61,7 +61,13 @@ def write_script(filename: str, script: list):
 output_file_no = 1
 script = []
 output_file = None
-for doc in glob.glob(os.path.join(docs_path, '*.md')):
+# Walk through any markdown files within the provided docs path.  The
+# original implementation only looked for files directly within
+# ``docs_path`` which meant that documentation organised into
+# sub-directories (as is the case in this repository) was ignored.  As a
+# result no scripts were generated.  Using ``recursive=True`` ensures all
+# markdown files are discovered.
+for doc in sorted(glob.glob(os.path.join(docs_path, '**', '*.md'), recursive=True)):
     print(doc)
     state = State.NONE
     ignore_next_script = False


### PR DESCRIPTION
## Summary
- update lab-script-generator to search subdirectories for markdown files

## Testing
- `python3 -m py_compile kubeadm-clusters/virtualbox/tools/lab-script-generator.py`

------
https://chatgpt.com/codex/tasks/task_e_683fdd007d90832b855d662abe954a37