### PR TITLE
Fix bug in get-highest-pod script

### DIFF
--- a/resources/staging-scripts/get-highest-pod.sh
+++ b/resources/staging-scripts/get-highest-pod.sh
@@ -15,10 +15,10 @@ get_highest_pod() {
         return 1
     fi
     
-    for cluster in cluster1 cluster2 cluster3 cluster4; 
-    do 
-        pod_info=$(kubectl top pods -A --context $cluster --no-headers | sort -nr -k${metric_key} | head -1 | awk '{print $1","$2","$'$metric_key'}')
-        current_metric=$(echo $pod_info | awk -F',' '{print $3}' | sed 's/m//' | sed 's/Mi//')
+    for cluster in cluster1 cluster2 cluster3 cluster4;
+    do
+        pod_info=$(kubectl top pods -A --context "$cluster" --no-headers | sort -nr -k"${metric_key}" | head -1 | awk '{print $1","$2","$'$metric_key'}')
+        current_metric=$(echo "$pod_info" | awk -F',' '{print $3}' | sed 's/m//' | sed 's/Mi//')
         if (( $(echo "$current_metric $highest" | awk '{if ($1 > $2) print 1; else print 0}') )); then
             highest=$current_metric
             highest_pod=$pod_info
@@ -27,7 +27,7 @@ get_highest_pod() {
     done
     
     highest_pod=${highest_pod%,*} # Remove everything after the last comma
-    echo $highest_cluster,$highest_pod
+    echo "$highest_cluster,$highest_pod"
 }
 
-get_highest_pod $@
+get_highest_pod "$@"


### PR DESCRIPTION
## Summary
- fix improper argument expansion and quoting in `get-highest-pod.sh`

## Testing
- `shellcheck resources/staging-scripts/get-highest-pod.sh && echo OK`
- `shellcheck resources/high_cpu_node.sh resources/high_cpu_pod.sh resources/high_memory_node.sh resources/high_memory_pod.sh metrics-staging-scripts/high_cpu_node.sh metrics-staging-scripts/high_cpu_pod.sh metrics-staging-scripts/high_memory_node.sh metrics-staging-scripts/high_memory_pod.sh >/tmp/shellcheck.log`

------
https://chatgpt.com/codex/tasks/task_e_683fdc833ebc832b975bf46c896a0eb5